### PR TITLE
Fix removed @*INC

### DIFF
--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -1,6 +1,6 @@
 use v6;
 use Test;
-BEGIN { @*INC.unshift( 'lib' ) }
+use lib 'lib';
 
 plan 3;
 


### PR DESCRIPTION
@*INC is no longer available. `use lib` is the new way.
